### PR TITLE
refactor(template): specify both width and height

### DIFF
--- a/templates/template.wikitext
+++ b/templates/template.wikitext
@@ -6,13 +6,13 @@
 [https://indierobloxwikis.org/?utm_source={{urlencode:{{SITENAME}}}}&utm_medium=Wiki&utm_campaign=IRWATemplate Learn More]
 </div>
 <div class="irwa-members">
-  <div class="irwa-member invert-member-icon-dark irwa-hybridcafe">[[File:HybridCafeWikiLogo.svg|class=hybrid-cafe-logo mw-no-invert|{{{imgsize|20px}}}|alt=Logo of the Hybrid Cafe Wiki|link=https://hybridcafe.wiki]] [https://hybridcafe.wiki Hybrid Cafe]</div>
-  <div class="irwa-member invert-member-icon irwa-pressure">[[File:PressureWikiLogo.png|class=pressure-logo mw-no-invert|{{{imgsize|20px}}}|alt=Logo of the Pressure Wiki|link=https://urbanshade.org]] [https://urbanshade.org Pressure]</div>
-  <div class="irwa-member irwa-utg">[[File:UTGWikiLogo.png|class=utg-logo mw-no-invert|{{{imgsize|20px}}}|alt=Logo of the Untitled Tag Game Wiki|link=https://utg.miraheze.org]] [https://utg.miraheze.org Untitled Tag Game]</div>
-  <div class="irwa-member irwa-gbp">[[File:GBPWikiLogo.png|class=gbp-logo mw-no-invert|{{{imgsize|20px}}}|alt=Logo of the Guts & Blackpowder Wiki|link=https://gbp.miraheze.org]] [https://gbp.miraheze.org Guts & Blackpowder]</div>
-  <div class="irwa-member irwa-outlaster">[[File:OutlasterWikiLogo.png|class=outlaster-logo mw-no-invert|{{{imgsize|20px}}}|alt=Logo of the Outlaster Wiki|link=https://outlaster.peakprecision.wiki]] [https://outlaster.peakprecision.wiki/ Outlaster]</div>
-  <div class="irwa-member irwa-fisch">[[File:FischWikiLogo.png|class=fisch-logo mw-no-invert|{{{imgsize|20px}}}|alt=Logo of Fischipedia|link=https://fischipedia.org]] [https://fischipedia.org Fischipedia]</div>
-  <div class="irwa-member invert-member-icon-dark irwa-dovedale">[[File:DovedaleWikiLogo.png|class=dovedale-logo mw-no-invert|{{{imgsize|20px}}}|alt=Logo of the Dovedale Railway Wiki|link=https://dovedale.wiki]] [https://dovedale.wiki Dovedale Railway]</div>
+  <div class="irwa-member invert-member-icon-dark irwa-hybridcafe">[[File:HybridCafeWikiLogo.svg|class=hybrid-cafe-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Hybrid Cafe Wiki|link=https://hybridcafe.wiki]] [https://hybridcafe.wiki Hybrid Cafe]</div>
+  <div class="irwa-member invert-member-icon irwa-pressure">[[File:PressureWikiLogo.png|class=pressure-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Pressure Wiki|link=https://urbanshade.org]] [https://urbanshade.org Pressure]</div>
+  <div class="irwa-member irwa-utg">[[File:UTGWikiLogo.png|class=utg-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Untitled Tag Game Wiki|link=https://utg.miraheze.org]] [https://utg.miraheze.org Untitled Tag Game]</div>
+  <div class="irwa-member irwa-gbp">[[File:GBPWikiLogo.png|class=gbp-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Guts & Blackpowder Wiki|link=https://gbp.miraheze.org]] [https://gbp.miraheze.org Guts & Blackpowder]</div>
+  <div class="irwa-member irwa-outlaster">[[File:OutlasterWikiLogo.png|class=outlaster-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Outlaster Wiki|link=https://outlaster.peakprecision.wiki]] [https://outlaster.peakprecision.wiki/ Outlaster]</div>
+  <div class="irwa-member irwa-fisch">[[File:FischWikiLogo.png|class=fisch-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of Fischipedia|link=https://fischipedia.org]] [https://fischipedia.org Fischipedia]</div>
+  <div class="irwa-member invert-member-icon-dark irwa-dovedale">[[File:DovedaleWikiLogo.png|class=dovedale-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Dovedale Railway Wiki|link=https://dovedale.wiki]] [https://dovedale.wiki Dovedale Railway]</div>
 </div>
 </div></includeonly>
 <noinclude>
@@ -74,10 +74,10 @@ This theme tries to adapt to the color theme of the skin. If the template looks 
 		},
 		"imgsize": {
 			"label": "Image sizes",
-			"description": "Specifies the sizes of images for each wiki icon.",
-			"example": "20px",
+			"description": "Specifies the sizes of images for each wiki icon. It is recommended to use a square size.",
+			"example": "20x20px",
 			"type": "string",
-			"default": "20px"
+			"default": "20x20px"
 		},
 		"theme": {
 			"label": "Color Theme",


### PR DESCRIPTION
This prevents non-square logo images from appearing bigger than others

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the description for the image size parameter to recommend using square dimensions.
  - Changed example and default values for the image size parameter from "20px" to "20x20px" for clarity.

- **Style**
  - Standardized image size formatting to use "20x20px" for all member wiki logos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->