### PR TITLE
fix(bot): update MissingPageError class name

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -1,4 +1,5 @@
 import { Mwn } from "mwn";
+import { MwnMissingPageError } from "mwn/build/error";
 import * as dotenv from "dotenv";
 import * as fs from "fs";
 import * as crypto from "crypto";
@@ -28,7 +29,6 @@ type File = {
 import wikisData from "./data/wikis.json";
 import templatesData from "./data/templates.json";
 import filesData from "./data/files.json";
-import { MwnError, MwnMissingPageError } from "mwn/build/error";
 
 const wikis: Wiki[] = wikisData;
 const templates: Template[] = templatesData;

--- a/bot.ts
+++ b/bot.ts
@@ -28,7 +28,7 @@ type File = {
 import wikisData from "./data/wikis.json";
 import templatesData from "./data/templates.json";
 import filesData from "./data/files.json";
-import { MwnError } from "mwn/build/error";
+import { MwnError, MwnMissingPageError } from "mwn/build/error";
 
 const wikis: Wiki[] = wikisData;
 const templates: Template[] = templatesData;
@@ -91,7 +91,7 @@ async function updateTemplateOnWiki(wiki: Wiki) {
         };
       });
     } catch (error) {
-      if (error instanceof MwnError.MissingPage) {
+      if (error instanceof MwnMissingPageError) {
         console.log(`ℹ️ Creating ${template.pageName} on wiki ${wiki.apiUrl}...`);
         try {
           await bot.create(template.pageName, content, editSummary);


### PR DESCRIPTION
This was changed in mwn 3.0.0.
This should fix https://github.com/Roblox-Indie-Wikis/irwa-templates/actions/runs/14695901698.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for missing template pages during edit operations to ensure more accurate detection and messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->