### PR TITLE
Could Sour Patch Kids fight my patches??? possibly...

### DIFF
--- a/templates/css/template.css
+++ b/templates/css/template.css
@@ -101,8 +101,9 @@ html.theme-dark .irwa-color-adaptive {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+  align-content: center;
   background-color: var(--irwa-members-background);
-  gap: 5px 10px;
+  gap: 5px 15px;
 }
 
 .irwa-member {

--- a/templates/css/template.css
+++ b/templates/css/template.css
@@ -65,13 +65,6 @@ html.theme-dark .irwa-color-adaptive {
   color: var(--irwa-navigation-color);
 }
 
-.irwa-header {
-  display: flex; 
-  flex-direction: row; 
-  align-items: center; 
-  gap: 5px
-}
-
 .irwa-header p {
   text-align: center;
   font-weight: bold;
@@ -112,7 +105,11 @@ html.theme-dark .irwa-color-adaptive {
 }
 
 .irwa-member {
-  min-width: 13em;
+  max-width: 13em;
+  display: flex; 
+  flex-direction: row; 
+  align-items: center; 
+  gap: 5px
 }
 
 /* Horizontal Configuration - Overrides various vertical configuration stuff */

--- a/templates/css/template.css
+++ b/templates/css/template.css
@@ -102,10 +102,11 @@ html.theme-dark .irwa-color-adaptive {
   flex-wrap: wrap;
   justify-content: center;
   background-color: var(--irwa-members-background);
+  gap: 5px 10px;
 }
 
 .irwa-member {
-  max-width: 13em;
+  /* min-width: 13em; */
   display: flex; 
   flex-direction: row; 
   align-items: center; 

--- a/templates/css/template.css
+++ b/templates/css/template.css
@@ -100,8 +100,7 @@ html.theme-dark .irwa-color-adaptive {
   padding: 10px;
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
-  align-content: center;
+  place-content: center;
   background-color: var(--irwa-members-background);
   gap: 5px 15px;
 }

--- a/templates/css/template.css
+++ b/templates/css/template.css
@@ -107,7 +107,6 @@ html.theme-dark .irwa-color-adaptive {
 }
 
 .irwa-member {
-  /* min-width: 13em; */
   display: flex; 
   flex-direction: row; 
   align-items: center; 

--- a/templates/css/template.css
+++ b/templates/css/template.css
@@ -65,6 +65,13 @@ html.theme-dark .irwa-color-adaptive {
   color: var(--irwa-navigation-color);
 }
 
+.irwa-header {
+  display: flex; 
+  flex-direction: row; 
+  align-items: center; 
+  gap: 5px
+}
+
 .irwa-header p {
   text-align: center;
   font-weight: bold;

--- a/templates/template.wikitext
+++ b/templates/template.wikitext
@@ -13,7 +13,7 @@
 	<div class="irwa-member irwa-fisch">[[File:FischWikiLogo.png|class=fisch-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of Fischipedia|link=https://fischipedia.org]] [https://fischipedia.org Fisch]</div>
 	<div class="irwa-member invert-member-icon-dark irwa-dovedale">[[File:DovedaleWikiLogo.png|class=dovedale-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Dovedale Railway Wiki|link=https://dovedale.wiki]] [https://dovedale.wiki Dovedale Railway]</div>
 	<div class="irwa-member irwa-industrialist">[[File:IndustrialistWikiLogo.png|class=industrialist-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Industrialist Wiki|link=https://industrialist.miraheze.org]] [https://industrialist.miraheze.org Industrialist]</div>
-	<div class="irwa-member irwa-sewh">[[File:SewhWikiLogo.png|class=sewh-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the SEWH Wiki|link=https://sewh.miraheze.org]] [https://sewh.miraheze.org SEWH]</div>
+	<div class="irwa-member irwa-sewh">[[File:SewhWikiLogo.png|class=sewh-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Something Evil Will Happen Wiki|link=https://sewh.miraheze.org]] [https://sewh.miraheze.org Something Evil Will Happen]</div>
 </div>
 </div></includeonly>
 <noinclude>


### PR DESCRIPTION
This pull request does:
- vertically aligning the image and name in IRWA header
- removing abbreviation of SEWH since other game wikis such as UTG and GBP don't
- changing `min-width: 13em` to `max-width: 13em` to prevent SEWH long name to overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Style
  * Member items now use a horizontal flex layout with centered alignment and consistent spacing for a cleaner presentation.
  * Adjusted sizing and gap rules for more consistent member item widths and improved spacing; color-adaptive elements centered with refined gap spacing.

* Accessibility
  * Replaced the acronym label with the full wiki name and updated image alt text for clearer, more descriptive display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->