### PR TITLE
refactor: sort wikis alphabetically

### DIFF
--- a/templates/template.wikitext
+++ b/templates/template.wikitext
@@ -6,14 +6,14 @@
 [https://indierobloxwikis.org/?utm_source={{urlencode:{{SITENAME}}}}&utm_medium=Wiki&utm_campaign=IRWATemplate Learn More] }}
 </div>
 <div class="irwa-members">
-	<div class="irwa-member invert-member-icon-dark irwa-hybridcafe">[[File:HybridCafeWikiLogo.svg|class=hybrid-cafe-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Hybrid Cafe Wiki|link=https://hybridcafe.wiki]] [https://hybridcafe.wiki Hybrid Cafe]</div>
-	<div class="irwa-member invert-member-icon irwa-pressure">[[File:PressureWikiLogo.png|class=pressure-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Pressure Wiki|link=https://urbanshade.org]] [https://urbanshade.org Pressure]</div>
-	<div class="irwa-member irwa-utg">[[File:UTGWikiLogo.png|class=utg-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Untitled Tag Game Wiki|link=https://tagging.wiki]] [https://tagging.wiki Untitled Tag Game]</div>
-	<div class="irwa-member irwa-gbp">[[File:GBPWikiLogo.png|class=gbp-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Guts & Blackpowder Wiki|link=https://gbp.miraheze.org]] [https://gbp.miraheze.org Guts & Blackpowder]</div>
-	<div class="irwa-member irwa-fisch">[[File:FischWikiLogo.png|class=fisch-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of Fischipedia|link=https://fischipedia.org]] [https://fischipedia.org Fisch]</div>
 	<div class="irwa-member invert-member-icon-dark irwa-dovedale">[[File:DovedaleWikiLogo.png|class=dovedale-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Dovedale Railway Wiki|link=https://dovedale.wiki]] [https://dovedale.wiki Dovedale Railway]</div>
+	<div class="irwa-member irwa-fisch">[[File:FischWikiLogo.png|class=fisch-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of Fischipedia|link=https://fischipedia.org]] [https://fischipedia.org Fisch]</div>
+	<div class="irwa-member irwa-gbp">[[File:GBPWikiLogo.png|class=gbp-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Guts & Blackpowder Wiki|link=https://gbp.miraheze.org]] [https://gbp.miraheze.org Guts & Blackpowder]</div>
+	<div class="irwa-member invert-member-icon-dark irwa-hybridcafe">[[File:HybridCafeWikiLogo.svg|class=hybrid-cafe-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Hybrid Cafe Wiki|link=https://hybridcafe.wiki]] [https://hybridcafe.wiki Hybrid Cafe]</div>
 	<div class="irwa-member irwa-industrialist">[[File:IndustrialistWikiLogo.png|class=industrialist-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Industrialist Wiki|link=https://industrialist.miraheze.org]] [https://industrialist.miraheze.org Industrialist]</div>
+	<div class="irwa-member invert-member-icon irwa-pressure">[[File:PressureWikiLogo.png|class=pressure-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Pressure Wiki|link=https://urbanshade.org]] [https://urbanshade.org Pressure]</div>
 	<div class="irwa-member irwa-sewh">[[File:SewhWikiLogo.png|class=sewh-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Something Evil Will Happen Wiki|link=https://sewh.miraheze.org]] [https://sewh.miraheze.org Something Evil Will Happen]</div>
+	<div class="irwa-member irwa-utg">[[File:UTGWikiLogo.png|class=utg-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Untitled Tag Game Wiki|link=https://tagging.wiki]] [https://tagging.wiki Untitled Tag Game]</div>
 </div>
 </div></includeonly>
 <noinclude>


### PR DESCRIPTION
Closes #52.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered the IRWA members list in the template. Moved Hybrid Cafe, Pressure, UTG, GBP, and Fisch to appear immediately after Dovedale. No content changes to any entries; only the display order is updated. The rest of the list, including Dovedale and Industrialist, remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->