### PR TITLE
fix(template): update IRWA logo URL

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -70,7 +70,7 @@ async function updateTemplateOnWiki(wiki: Wiki) {
     if (wiki.allianceLogoUrl) {
       // replace url on 3rd party wikis
       content = content.replace(
-        "https://static.wikitide.net/urbanshadewiki/d/d1/IRWA_Logo.svg",
+        "https://static.wikitide.net/commonswiki/e/e0/IRWA_Logo_Black.svg",
         wiki.allianceLogoUrl
       );
     }

--- a/templates/css/template.css
+++ b/templates/css/template.css
@@ -52,7 +52,7 @@ html.theme-dark .irwa-color-adaptive {
 
 /* Base Stuff */
 .irwa-navigation {
-  background-image: url("https://static.wikitide.net/urbanshadewiki/d/d1/IRWA_Logo.svg");
+  background-image: url("https://static.wikitide.net/commonswiki/e/e0/IRWA_Logo_Black.svg");
   background-size: contain;
   background-position: center; /* For vertical configuration, is overridden in horizontal configuration */
   background-repeat: no-repeat;


### PR DESCRIPTION
The logo is now hosted on commons, as urbanshade has left the alliance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the navigation logo throughout the application to a new variant, enhancing visual branding and consistency across all pages.
  * Logo sizing and positioning remain unchanged, preserving the user interface experience while delivering an improved overall appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->