### PR TITLE
fix: update UTG URL to custom domain again

### DIFF
--- a/data/wikis.json
+++ b/data/wikis.json
@@ -4,7 +4,7 @@
     "accessToken": "MIRAHEZE_ACCESS_TOKEN"
   },
   {
-    "apiUrl": "https://utg.miraheze.org/w/api.php",
+    "apiUrl": "https://tagging.wiki/w/api.php",
     "accessToken": "MIRAHEZE_ACCESS_TOKEN"
   },
   {

--- a/templates/template.wikitext
+++ b/templates/template.wikitext
@@ -21,7 +21,7 @@
 	<div class="irwa-member irwa-rt3">[[File:RestaurantTycoon3WikiLogo.png|class=rt3-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Restaurant Tycoon 3 Wiki|link=https://rt3.ugwiki.org]] [https://rt3.ugwiki.org Restaurant Tycoon 3]</div>
 	<div class="irwa-member irwa-sewh">[[File:SewhWikiLogo.png|class=sewh-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Something Evil Will Happen Wiki|link=https://sewh.miraheze.org]] [https://sewh.miraheze.org Something Evil Will Happen]</div>
 	<div class="irwa-member irwa-umt">[[File:UMTWikiLogo.png|class=umt-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Ultimate Mining Tycoon Wiki|link=https://umt.miraheze.org]] [https://umt.miraheze.org Ultimate Mining Tycoon]</div>
-	<div class="irwa-member irwa-utg">[[File:UTGWikiLogo.png|class=utg-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Untitled Tag Game Wiki|link=https://utg.miraheze.org]] [https://utg.miraheze.org Untitled Tag Game]</div>
+	<div class="irwa-member irwa-utg">[[File:UTGWikiLogo.png|class=utg-logo mw-no-invert|{{{imgsize|20x20px}}}|alt=Logo of the Untitled Tag Game Wiki|link=https://tagging.wiki]] [https://tagging.wiki Untitled Tag Game]</div>
 </div>
 </div></includeonly>
 <noinclude>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Untitled Tag Game links to use the new `tagging.wiki` domain.
  * Updated wiki API connectivity to point to the new domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->